### PR TITLE
read papertrailHost from serverless.yml

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ class PapertrailLogging {
     let templateFile = fs.readFileSync(templatePath, 'utf-8');
 
     let handlerFunction = templateFile
+      .replace('%papertrailHost%', this.service.custom.papertrail.host)
       .replace('%papertrailPort%', this.service.custom.papertrail.port)
       .replace('%papertrailHostname%', this.service.service)
       .replace('%papertrailProgram%', this.service.provider.stage);

--- a/src/logger.handler.js
+++ b/src/logger.handler.js
@@ -35,7 +35,7 @@ exports.handler = function (event, context, callback) {
     transports: [],
   });
   logger.add(papertrail, {
-    host: 'logs.papertrailapp.com',
+    host: '%papertrailHost%',
     port: '%papertrailPort%',
     hostname: '%papertrailHostname%',
     program: '%papertrailProgram%',


### PR DESCRIPTION
Not all clients use logs.papertrailapp.com, I use logs3.papertrailapp.com for example.