### PR TITLE
make Papertrail log host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The plugin ignores implicit Lambda logs (starting with `START`, `END` and `REPOR
 ```yaml
 custom:
   papertrail:
-    port: 1234
+    host: logsN.papertrailapp.com
+    port: 12345
     
 plugins:
 - '@keboola/serverless-papertrail-logging'

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ class PapertrailLogging {
     if (!_.has(this.service, 'custom.papertrail.port')) {
       throw new this.serverless.classes.Error('Configure Papertrail port in custom.papertrail.port of the serverless.yml');
     }
+    if (!_.has(this.service, 'custom.papertrail.host')) {
+      throw new this.serverless.classes.Error('Configure Papertrail host in custom.papertrail.host of the serverless.yml');
+    }
   }
 
   static getFunctionName() {
@@ -56,6 +59,7 @@ class PapertrailLogging {
 
     let handlerFunction = templateFile
       .replace('%papertrailPort%', this.service.custom.papertrail.port)
+      .replace('%papertrailHost%', this.service.custom.papertrail.host)
       .replace('%papertrailHostname%', this.service.service)
       .replace('%papertrailProgram%', this.service.provider.stage);
     fs.writeFileSync(path.join(functionPath, 'handler.js'), handlerFunction);

--- a/src/logger.handler.js
+++ b/src/logger.handler.js
@@ -38,7 +38,7 @@ exports.handler = function (event, context, callback) {
     transports: [],
   });
   logger.add(papertrail, {
-    host: 'logs.papertrailapp.com',
+    host: '%papertrailHost%',
     port: '%papertrailPort%',
     hostname: '%papertrailHostname%',
     program: '%papertrailProgram%',


### PR DESCRIPTION
Papertrail has multiple log hosts, so when a destination is assigned, the `logsN` part at the beginning of the host can vary. These changes allow this plugin to work for all Papertrail destinations. 

Apologies if I didn't get all the details right - I'm not a serverless user myself. Please let me know if I can make any changes that would improve the PR.