### PR TITLE
move host variable assignment for greater flexibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,6 @@ class PapertrailLogging {
     if (!_.has(this.service, 'custom.papertrail.port')) {
       throw new this.serverless.classes.Error('Configure Papertrail port in custom.papertrail.port of the serverless.yml');
     }
-
-    this.papertrailHost = _.get(this.service, 'custom.papertrail.host', 'logs.papertrailapp.com');
   }
 
   static getFunctionName() {
@@ -39,6 +37,8 @@ class PapertrailLogging {
     if (!fs.existsSync(functionPath)) {
       fs.mkdirSync(functionPath);
     }
+
+    this.papertrailHost = _.get(this.service, 'custom.papertrail.host', 'logs.papertrailapp.com');
 
     const loggerFunctionFullName = `${this.service.service}-${this.service.provider.stage}-${PapertrailLogging.getFunctionName()}`;
     _.merge(


### PR DESCRIPTION
This way we can let the serverless framework resolve the variable for us, it doesn't have to be hardcoded.

Ie.
```
custom:
  env:
     PAPERTRAIL_HOST: logs3.papertrailapp.com
  papertrail:
    host: ${self.custom.env.PAPERTRAIL_HOST}
```