### PR TITLE
feat: make papertrail hostname and program configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,11 +56,14 @@ class PapertrailLogging {
     let templatePath = path.resolve(__dirname, './logger.handler.js');
     let templateFile = fs.readFileSync(templatePath, 'utf-8');
 
+    const papertrailHostname = _.get(this.service, 'custom.papertrail.hostname', this.service.service);
+    const papertrailProgram = _.get(this.service, 'custom.papertrail.program', this.service.provider.stage);
+
     let handlerFunction = templateFile
       .replace('%papertrailHost%', this.papertrailHost)
       .replace('%papertrailPort%', this.service.custom.papertrail.port)
-      .replace('%papertrailHostname%', this.service.service)
-      .replace('%papertrailProgram%', this.service.provider.stage);
+      .replace('%papertrailHostname%', papertrailHostname)
+      .replace('%papertrailProgram%', papertrailProgram);
     fs.writeFileSync(path.join(functionPath, 'handler.js'), handlerFunction);
     this.service.functions[PapertrailLogging.getFunctionName()] = {
       handler: `${PapertrailLogging.getFunctionName()}/handler.handler`,


### PR DESCRIPTION
Hi! The plugin has been working great for us but we had to customize `hostname` and `program` for filtering / grouping purposes. I think this might be helpful for other people as well. The parameters are still optional.