### PR TITLE
docs: update installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin ignores implicit Lambda logs (starting with `START`, `END` and `REPOR
 
 ### Installation
 
-1. Install npm package: `yarn add @keboola/serverless-papertrail-logging --dev`
+1. Install npm package: `yarn add @keboola/serverless-papertrail-logging`
 2. Add plugin to your `serverless.yml`:
 ```yaml
 custom:


### PR DESCRIPTION
As mentioned in #5 , the dependencies of this plugin need to be installed in `dependencies` instead of `devDependencies`.
Otherwise the lambda created by the plugin will not have access to its dependencies like winston and lodash.

Thanks for this plugin it helped me a lot! 🙏 